### PR TITLE
Fix typo in debug description

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1814,7 +1814,7 @@ export class Stream<T> implements InternalListener<T> {
   debug(labelOrSpy: (t: T) => any): Stream<T>;
   /**
    * Returns an output stream that identically behaves like the input stream,
-   * but also runs a `spy` function fo each event, to help you debug your app.
+   * but also runs a `spy` function for each event, to help you debug your app.
    *
    * *debug* takes a `spy` function as argument, and runs that for each event
    * happening on the input stream. If you don't provide the `spy` argument,


### PR DESCRIPTION
"fo each" -> "for each"